### PR TITLE
Feature: list datasets

### DIFF
--- a/src/main/java/org/janelia/n5anndata/io/AnnDataPath.java
+++ b/src/main/java/org/janelia/n5anndata/io/AnnDataPath.java
@@ -110,6 +110,23 @@ public class AnnDataPath {
 		}
 	}
 
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj){
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		final AnnDataPath that = (AnnDataPath) obj;
+		return field == that.field && keys.equals(that.keys);
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * field.hashCode() + keys.hashCode();
+	}
+
 	/**
 	 * Returns the parent path of the current path as a new AnnDataPath object.
 	 * If the current path is a field, the root path is returned.

--- a/src/test/java/org/janelia/n5anndata/io/AnnDataPathTest.java
+++ b/src/test/java/org/janelia/n5anndata/io/AnnDataPathTest.java
@@ -49,6 +49,14 @@ public class AnnDataPathTest {
 	}
 
 	@Test
+	public void same_paths_are_equal() {
+		final AnnDataPath path1 = new AnnDataPath(AnnDataField.OBS, "test", "foo");
+		final AnnDataPath path2 = new AnnDataPath(AnnDataField.OBS, "test", "foo");
+		assertEquals(path1, path2);
+		assertEquals(path1.hashCode(), path2.hashCode());
+	}
+
+	@Test
 	public void correct_path_from_string() {
 		final String expectedPath = "/obs/test/foo";
 		final AnnDataPath actualPath = AnnDataPath.fromString(expectedPath);

--- a/src/test/java/org/janelia/n5anndata/io/BaseIoTest.java
+++ b/src/test/java/org/janelia/n5anndata/io/BaseIoTest.java
@@ -116,7 +116,7 @@ public class BaseIoTest {
 	}
 
 
-	protected static <T> void assertEquals(final RandomAccessibleInterval<T> expected, final Img<T> actual) {
+	protected static <T> void assertImgEquals(final RandomAccessibleInterval<T> expected, final Img<T> actual) {
 		assertArrayEquals(expected.dimensionsAsLongArray(), actual.dimensionsAsLongArray(), "Dimensions do not match.");
 		final Cursor<T> cursor = actual.cursor();
 		while (cursor.hasNext()) {

--- a/src/test/java/org/janelia/n5anndata/io/IoTest.java
+++ b/src/test/java/org/janelia/n5anndata/io/IoTest.java
@@ -58,6 +58,7 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class IoTest extends BaseIoTest {
@@ -84,7 +85,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.initializeAnnData(OBS_NAMES, VAR_NAMES, writer, ARRAY_OPTIONS);
 			AnnDataUtils.writeNumericalArray(MATRIX, writer, path, MATRIX_OPTIONS, AnnDataFieldType.DENSE_ARRAY);
 			final Img<DoubleType> actual = AnnDataUtils.readNumericalArray(writer, path);
-			assertEquals(MATRIX, actual);
+			assertImgEquals(MATRIX, actual);
 		}
 	}
 
@@ -98,7 +99,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.writeNumericalArray(transposed, writer, path, MATRIX_OPTIONS, AnnDataFieldType.CSR_MATRIX);
 			final Img<DoubleType> actual = AnnDataUtils.readNumericalArray(writer, path);
 			assertInstanceOf(CsrMatrix.class, actual);
-			assertEquals(transposed, actual);
+			assertImgEquals(transposed, actual);
 		}
 	}
 
@@ -112,7 +113,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.writeNumericalArray(csr, writer, path, MATRIX_OPTIONS, AnnDataFieldType.CSC_MATRIX);
 			final Img<DoubleType> actual = AnnDataUtils.readNumericalArray(writer, path);
 			assertInstanceOf(CscMatrix.class, actual);
-			assertEquals(MATRIX, actual);
+			assertImgEquals(MATRIX, actual);
 		}
 	}
 
@@ -126,7 +127,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.writeNumericalArray(csc, writer, path, MATRIX_OPTIONS, AnnDataFieldType.DENSE_ARRAY);
 			final Img<DoubleType> actual = AnnDataUtils.readNumericalArray(writer, path);
 			Assertions.assertEquals(AnnDataUtils.getFieldType(writer, path), AnnDataFieldType.DENSE_ARRAY);
-			assertEquals(MATRIX, actual);
+			assertImgEquals(MATRIX, actual);
 		}
 	}
 
@@ -139,7 +140,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.initializeAnnData(OBS_NAMES, VAR_NAMES, writer, ARRAY_OPTIONS);
 			AnnDataUtils.writeNumericalArray(expected, writer, path, MATRIX_OPTIONS, AnnDataFieldType.DENSE_ARRAY);
 			final Img<FloatType> actual = AnnDataUtils.readNumericalArray(writer, path);
-			assertEquals(expected, actual);
+			assertImgEquals(expected, actual);
 		}
 	}
 
@@ -152,7 +153,7 @@ public class IoTest extends BaseIoTest {
 			AnnDataUtils.initializeAnnData(OBS_NAMES, VAR_NAMES, writer, ARRAY_OPTIONS);
 			AnnDataUtils.writeNumericalArray(expected, writer, path, MATRIX_OPTIONS, AnnDataFieldType.DENSE_ARRAY);
 			final Img<ShortType> actual = AnnDataUtils.readNumericalArray(writer, path);
-			assertEquals(expected, actual);
+			assertImgEquals(expected, actual);
 		}
 	}
 
@@ -193,7 +194,7 @@ public class IoTest extends BaseIoTest {
 			path = path.append("test3");
 			AnnDataUtils.writeNumericalArray(MATRIX, writer, path, MATRIX_OPTIONS, AnnDataFieldType.DENSE_ARRAY);
 			final Img<DoubleType> actual = AnnDataUtils.readNumericalArray(writer, path);
-			assertEquals(MATRIX, actual);
+			assertImgEquals(MATRIX, actual);
 		}
 	}
 


### PR DESCRIPTION
I implemented a method to list datasets in a `MAPPING` or `DATA_FRAME` (which are the only types that allow for nested datasets in the anndata model) together with their data type.

Only anndata-relevant datasets are listed, i.e., datasets that have `encoding-type` and `encoding-version` metadata.